### PR TITLE
Fix opam file

### DIFF
--- a/ppx_string_interpolation.opam
+++ b/ppx_string_interpolation.opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "ppx_string_interpolation"
 synopsis: "String interpolation PPX preprocessor"
 description: "
 String interpolation PPX preprocessor.
@@ -12,20 +11,14 @@ doc: "https://bloomberg.github.io/ppx_string_interpolation/README.md"
 dev-repo: "git+https://github.com/bloomberg/ppx_string_interpolation.git"
 license: "Apache-2.0"
 
-url {
-  src: "https://github.com/bloomberg/ppx_string_interpolation/archive/1.0.0.tar.gz"
-    checksum: "md5=3e65a57fd7fb6c7025e7ade74b22c83a"
-    }
-
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 
 depends: [
-  "dune" {>= "1.5"}
+  "dune" {>= "1.7"}
   "ocaml" {>= "4.04.1"}
   "ppxlib" {>= "0.18.0"}
   "sedlex"
 ]
-


### PR DESCRIPTION
Return fixes from the opam-repository.
* `name` is redundant
* `url` should never be used in the source repository
* `dune` requires at least 1.7 (see your `dune-project` file)
* `{dev}` should be used instead of `{pinned}` (fixed in dune 2.7)